### PR TITLE
fix:修复使用 GrantUiAccess 时 顶层效果窗口 出现在任务栏的问题

### DIFF
--- a/GrantUiAccess/Plugin.cs
+++ b/GrantUiAccess/Plugin.cs
@@ -5,8 +5,11 @@ using ClassIsland.Core.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Runtime.InteropServices;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using ClassIsland.Core;
+using System.Linq;
+using System.Text;
 
 namespace GrantUiAccess;
 
@@ -34,14 +37,70 @@ public class Plugin : PluginBase
                 return;
             }
 
-
             if (AppBase.Current.MainWindow.Topmost != true)
                 return;
             AppBase.Current.MainWindow.Topmost = false;
             AppBase.Current.MainWindow.Topmost = true;
+
+            FixTopmostEffectWindow();
         });
+    }
+
+    private static void FixTopmostEffectWindow()
+    {
+        var windows = AppBase.Current?.GetType()
+            .GetProperty("Windows", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public)
+            ?.GetValue(AppBase.Current) as System.Collections.IEnumerable;
+
+        if (windows == null)
+            return;
+
+        foreach (var windowObj in windows)
+        {
+            if (windowObj is not Window window)
+                continue;
+
+            if (window.GetType().Name != "TopmostEffectWindow")
+                continue;
+
+            if (!window.IsVisible)
+                continue;
+
+            window.Topmost = false;
+            window.Topmost = true;
+
+            var handle = window.TryGetPlatformHandle()?.Handle ?? nint.Zero;
+            if (handle == nint.Zero)
+                continue;
+
+            var exStyle = GetWindowLong(handle, GWL_EXSTYLE);
+            if ((exStyle & WS_EX_TOOLWINDOW) == 0)
+            {
+                SetWindowLong(handle, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
+                SetWindowPos(handle, HWND_TOPMOST, 0, 0, 0, 0,
+                    SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+            }
+        }
     }
 
     [DllImport("uiaccess.dll", EntryPoint = "PrepareForUIAccess", CallingConvention = CallingConvention.Cdecl)]
     private static extern int PrepareForUIAccess();
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern int GetWindowLong(nint hWnd, int nIndex);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern int SetWindowLong(nint hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter,
+        int X, int Y, int cx, int cy, uint uFlags);
+
+    private const int GWL_EXSTYLE = -20;
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private static readonly nint HWND_TOPMOST = new(-1);
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint SWP_FRAMECHANGED = 0x0020;
 }


### PR DESCRIPTION
在ClassIsland2.0以上版本使用 GrantUiAccess 2.0.0.0时，每次触发"提醒"时，任务栏会出现无法关闭的"顶层效果窗口"任务。本PR修复了此问题。

可能的原因：MainWindow.Topmost 重置时，ShowInTaskbar = false 和 WS_EX_TOOLWINDOW 样式被刷新了，不再起作用，而GrantUiAccess为了生效，在 AppStarted 事件中重置了 MainWindow.Topmost ，导致样式被错误的刷新

怎么修的：重置 MainWindow.Topmost 后，同步重置 TopmostEffectWindow 的状态

增加了 FixTopmostEffectWindow()  方法，常量 GWL_EXSTYLE , WS_EX_TOOLWINDOW , HWND_TOPMOST , SWP_* 和win32api声明

在2.0.3.2版本中，使用修复后的插件，问题不再出现